### PR TITLE
닉네임 한계 수정 (#97)

### DIFF
--- a/src/main/java/com/example/ggj_be/domain/member/Member.java
+++ b/src/main/java/com/example/ggj_be/domain/member/Member.java
@@ -123,7 +123,8 @@ public class Member {
 
     //닉네임 변경
     public ApiResponse<Object> changeNickName(String newNickName) {
-        if(newNickName.length() >8){
+        if(newNickName.length() >10){
+
             throw new ApiException(ErrorStatus._NICKNAME_CANNOTOVER8);
         }
         this.nickName = newNickName;

--- a/src/main/java/com/example/ggj_be/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/ggj_be/global/response/code/status/ErrorStatus.java
@@ -21,7 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER400", "요청한 회원 정보를 찾을 수 없습니다.."),
     _MEMBER_DUPLICATED_ID(HttpStatus.BAD_REQUEST, "MEMBER401", "중복된 아이디입니다."),
     _MEMBER_DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER402", "중복된 닉네임입니다."),
-    _NICKNAME_CANNOTOVER8(HttpStatus.BAD_REQUEST, "MEMBER403", "닉네임은 8자를 초과 할 수 없습니다."),
+    _NICKNAME_CANNOTOVER8(HttpStatus.BAD_REQUEST, "MEMBER403", "닉네임은 10자를 초과 할 수 없습니다."),
     _ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "등록된 은행 계좌가 없습니다."),
     // 관리자 관련
     _ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN400", "요청한 관리자 정보를 찾을 수 없습니다.."),
@@ -50,7 +50,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _USER_DUPLICATE(HttpStatus.BAD_REQUEST, "MAIL401", "중복된 이메일 입니다."),
 
     //사진 관련
-    _IMG_NOT_FOUND(HttpStatus.NOT_FOUND, "IMG400", "이미지를 찾을 수 없습니다.");
+    _IMG_NOT_FOUND(HttpStatus.NOT_FOUND, "IMG400", "이미지를 찾을 수 없습니다."),
+
+    //은행 관련
+    _BANK_NOT_FOUND(HttpStatus.NOT_FOUND, "BANK400", "해당하는 은행을 찾을 수 없습니다.");
+
 
 
 


### PR DESCRIPTION
* 기본 프로필 이미지 선택과 닉네임 설정 통합

* Get /profile 실행시 은행정보 반환 DTO 수정 완료

* 회원의 은행정보를 반환하는 GET api/mypage/bank-info 구현 완료

* 닉네임 10자 초과 불가로 수정